### PR TITLE
docs: fix tool versions hook example

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
         args:
           - --verbose
       - id: check-max-one-sentence-per-line
+      - id: sync-tool-versions
   - repo: https://github.com/pre-commit/pre-commit
     rev: v4.5.1
     hooks:

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -237,7 +237,7 @@
           - path: .pre-commit-config.yaml
             pattern: rust:\\s*([0-9.]+)
       - name: python
-        version: 3.14
+        version: '3.14'
         entries:
           - path: .python-version
             pattern: ([0-9]+\.[0-9]+)

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ sync_versions:
       - path: .pre-commit-config.yaml
         pattern: rust:\s*([0-9.]+)
   - name: python
-    version: 3.14
+    version: '3.14'
     entries:
       - path: .python-version
         pattern: ([0-9]+\.[0-9]+)

--- a/dev_tools/sync_tool_versions.py
+++ b/dev_tools/sync_tool_versions.py
@@ -69,7 +69,7 @@ def _require_list(value: object, message: str) -> list:
 
 def _require_non_empty_str(value: object, message: str) -> str:
     if not isinstance(value, str):
-        msg = message + f"with type str. Got {type(value).__name__} instead."
+        msg = message + f" with type str. Got {type(value).__name__} instead."
         raise TypeError(msg)
     if not value:
         raise ValueError(message)

--- a/dev_tools/sync_tool_versions.py
+++ b/dev_tools/sync_tool_versions.py
@@ -69,7 +69,8 @@ def _require_list(value: object, message: str) -> list:
 
 def _require_non_empty_str(value: object, message: str) -> str:
     if not isinstance(value, str):
-        raise TypeError(message)
+        msg = message + f"with type str. Got {type(value).__name__} instead."
+        raise TypeError(msg)
     if not value:
         raise ValueError(message)
     return value


### PR DESCRIPTION
Yaml recognizes value `3.12` as float, not str:

```py3
from ruamel.yaml import YAML
yaml = YAML(typ="safe")
config=r"""name: tool-versions
sync_versions:
  - name: python
    version: 3.12
    entries:
      - path: .python-version
        pattern: ([0-9]+\.[0-9]+)
"""
data = yaml.load(config)
type(data['sync_versions'][0]['version'])  # prints '<class 'float'>'
```

This causes `dev_tools/sync_tool_versions.py` to raise

```
  Error: invalid config in /home/chris/improvements/.versions.yaml: Each sync_versions entry must have a non-empty 'version' in /home/chris/improvements/.versions.yaml
```

with the config from the example. This doesn't hint to the root problem. Thus, improve the error message and fix the example in the docs. Alternatively, we could convert float to str to simplify the config file.

Btw:

```py3
>>> from ruamel.yaml import YAML
>>> yaml = YAML(typ="safe")
>>> type(yaml.load("version: 1.91.0")['version'])
<class 'str'>
```