### PR TITLE
[codex] extract Bazel build file parsing utility

### DIFF
--- a/dev_tools/build_file_parsing_util.py
+++ b/dev_tools/build_file_parsing_util.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+RULE_PATTERN = re.compile(r"(?m)(?<![A-Za-z0-9_])(?P<rule>[A-Za-z_][A-Za-z0-9_]*)\s*\(")
+
+
+@dataclass(frozen=True)
+class RuleCall:
+    """A parsed Bazel rule call."""
+
+    rule_kind: str
+    body: str
+
+
+def remove_comments(content: str) -> str:
+    return re.sub(r"(?m)#.*$", "", content)
+
+
+def find_rule_calls(content: str, rule_name: str | None = None) -> Iterator[RuleCall]:
+    content_without_comments = remove_comments(content)
+
+    for match in RULE_PATTERN.finditer(content_without_comments):
+        if rule_name is not None and match.group("rule") != rule_name:
+            continue
+
+        open_parens_count = 1
+        current_index = match.end()
+
+        while current_index < len(content_without_comments) and open_parens_count > 0:
+            character = content_without_comments[current_index]
+            if character == "(":
+                open_parens_count += 1
+            elif character == ")":
+                open_parens_count -= 1
+            current_index += 1
+
+        if open_parens_count == 0:
+            yield RuleCall(
+                rule_kind=match.group("rule"),
+                body=content_without_comments[match.end() : current_index - 1],
+            )
+
+
+def rule_has_tag(rule_body: str, tag: str) -> bool:
+    tags_pattern = re.compile(r'(?ms)(?<![A-Za-z0-9_])tags\s*=\s*\[[^\]]*["\']' + re.escape(tag) + r'["\']')
+    return bool(tags_pattern.search(remove_comments(rule_body)))

--- a/dev_tools/check_rule_has_tag.py
+++ b/dev_tools/check_rule_has_tag.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import re
 import sys
 from typing import TYPE_CHECKING
 
+from dev_tools.build_file_parsing_util import find_rule_calls, rule_has_tag
 from dev_tools.git_hook_utils import create_default_parser
 
 if TYPE_CHECKING:
@@ -19,38 +19,6 @@ def parse_arguments(argv: Sequence[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def _remove_comments(content: str) -> str:
-    return re.sub(r"(?m)#.*$", "", content)
-
-
-def find_rule_calls(content: str, rule_name: str) -> list[str]:
-    content_without_comments = _remove_comments(content)
-    rule_pattern = re.compile(rf"(?m)(?<![A-Za-z0-9_]){re.escape(rule_name)}\s*\(")
-    rule_calls: list[str] = []
-
-    for match in rule_pattern.finditer(content_without_comments):
-        open_parens_count = 1
-        current_index = match.end()
-
-        while current_index < len(content_without_comments) and open_parens_count > 0:
-            character = content_without_comments[current_index]
-            if character == "(":
-                open_parens_count += 1
-            elif character == ")":
-                open_parens_count -= 1
-            current_index += 1
-
-        if open_parens_count == 0:
-            rule_calls.append(content_without_comments[match.end() : current_index - 1])
-
-    return rule_calls
-
-
-def rule_has_tag(rule_body: str, tag: str) -> bool:
-    tags_pattern = re.compile(r'(?ms)(?<![A-Za-z0-9_])tags\s*=\s*\[[^\]]*["\']' + re.escape(tag) + r'["\']')
-    return bool(tags_pattern.search(_remove_comments(rule_body)))
-
-
 def is_rule_missing_tag(rule_body: str, tag: str) -> bool:
     return not rule_has_tag(rule_body, tag)
 
@@ -59,8 +27,9 @@ def find_invalid_files(filenames: Sequence[Path], rule_name: str, tag: str) -> l
     return [
         filename
         for filename in filenames
-        if (rule_calls := find_rule_calls(filename.read_text(), rule_name))
-        and any(is_rule_missing_tag(rule_body, tag) for rule_body in rule_calls)
+        if any(
+            is_rule_missing_tag(rule_call.body, tag) for rule_call in find_rule_calls(filename.read_text(), rule_name)
+        )
     ]
 
 

--- a/tests/test_build_file_parsing_util.py
+++ b/tests/test_build_file_parsing_util.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+
+from dev_tools.build_file_parsing_util import find_rule_calls, rule_has_tag
+
+
+@pytest.mark.parametrize(
+    ("content", "expected_rule_kinds"),
+    [
+        ('py_venv(name = "venv")', ["py_venv"]),
+        ('other_rule(name = "x")', ["other_rule"]),
+        (
+            """
+py_venv(name = "venv")
+pkg_tar(name = "archive")
+py_venv(
+    name = "second",
+)
+""",
+            ["py_venv", "pkg_tar", "py_venv"],
+        ),
+    ],
+)
+def test_find_rule_calls_for_content_should_return_rule_kinds(content: str, expected_rule_kinds: list[str]) -> None:
+    assert [rule_call.rule_kind for rule_call in find_rule_calls(content)] == expected_rule_kinds
+
+
+def test_find_rule_calls_for_rule_name_should_filter_rule_calls() -> None:
+    content = """
+py_venv(name = "venv")
+pkg_tar(name = "archive")
+"""
+
+    assert [rule_call.rule_kind for rule_call in find_rule_calls(content, "py_venv")] == ["py_venv"]
+
+
+def test_find_rule_calls_for_nested_parentheses_should_return_full_rule_body() -> None:
+    content = """
+py_venv(
+    name = name + "_venv",
+    deps = [":{}_foo".format(name)],
+    package_collisions = "ignore",
+    tags = ["manual"],
+)
+"""
+
+    rule_call = next(find_rule_calls(content, "py_venv"))
+
+    assert '":{}_foo".format(name)' in rule_call.body
+    assert 'tags = ["manual"]' in rule_call.body
+
+
+@pytest.mark.parametrize(
+    ("rule_body", "tag"),
+    [
+        ('name = "venv", tags = ["manual"]', "manual"),
+        ('name = "venv", tags = ["manual", "no-remote"]', "manual"),
+        ('name = "venv", tags = [\n    "manual",\n]', "manual"),
+        ('name = "archive", tags = ["no-remote"]', "no-remote"),
+    ],
+)
+def test_rule_has_tag_for_matching_tag_should_return_true(rule_body: str, tag: str) -> None:
+    assert rule_has_tag(rule_body, tag) is True
+
+
+@pytest.mark.parametrize(
+    ("rule_body", "tag"),
+    [
+        ('name = "venv"', "manual"),
+        ('name = "venv", tags = ["not-manual"]', "manual"),
+        ('name = "venv", tags = []  # manual', "manual"),
+        ('name = "archive", tags = ["remote"]', "no-remote"),
+        ('name = "thing", package_collisions = "ignore"', "manual"),
+    ],
+)
+def test_rule_has_tag_for_non_matching_tag_should_return_false(rule_body: str, tag: str) -> None:
+    assert rule_has_tag(rule_body, tag) is False

--- a/tests/test_check_rule_has_tag.py
+++ b/tests/test_check_rule_has_tag.py
@@ -3,71 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import pytest
-
-from dev_tools.check_rule_has_tag import find_invalid_files, find_rule_calls, rule_has_tag
+from dev_tools.check_rule_has_tag import find_invalid_files
 
 if TYPE_CHECKING:
     from pyfakefs.fake_filesystem import FakeFilesystem
-
-
-@pytest.mark.parametrize(
-    ("content", "expected_rule_count"),
-    [
-        ('py_venv(name = "venv")', 1),
-        ('other_rule(name = "x")', 0),
-        (
-            """
-py_venv(name = "venv")
-pkg_tar(name = "archive")
-py_venv(
-    name = "second",
-)
-""",
-            2,
-        ),
-        (
-            """
-py_venv(
-    name = name + "_venv",
-    deps = [":{}_foo".format(name)],
-    package_collisions = "ignore",
-    tags = ["manual"],
-)
-""",
-            1,
-        ),
-    ],
-)
-def test_find_rule_calls_for_content_should_return_expected_rule_count(content: str, expected_rule_count: int) -> None:
-    assert len(find_rule_calls(content, "py_venv")) == expected_rule_count
-
-
-@pytest.mark.parametrize(
-    ("rule_body", "tag"),
-    [
-        ('name = "venv", tags = ["manual"]', "manual"),
-        ('name = "venv", tags = ["manual", "no-remote"]', "manual"),
-        ('name = "venv", tags = [\n    "manual",\n]', "manual"),
-        ('name = "archive", tags = ["no-remote"]', "no-remote"),
-    ],
-)
-def test_rule_has_tag_for_matching_tag_should_return_true(rule_body: str, tag: str) -> None:
-    assert rule_has_tag(rule_body, tag) is True
-
-
-@pytest.mark.parametrize(
-    ("rule_body", "tag"),
-    [
-        ('name = "venv"', "manual"),
-        ('name = "venv", tags = ["not-manual"]', "manual"),
-        ('name = "venv", tags = []  # manual', "manual"),
-        ('name = "archive", tags = ["remote"]', "no-remote"),
-        ('name = "thing", package_collisions = "ignore"', "manual"),
-    ],
-)
-def test_rule_has_tag_for_non_matching_tag_should_return_false(rule_body: str, tag: str) -> None:
-    assert rule_has_tag(rule_body, tag) is False
 
 
 def test_find_invalid_files_for_rule_without_tag_should_return_file(fs: FakeFilesystem) -> None:


### PR DESCRIPTION
## Summary

Extracts shared Bazel BUILD file parsing helpers into `dev_tools.build_file_parsing_util`.

This moves rule-call parsing and tag detection out of `check_rule_has_tag.py`, keeps the existing hook behavior unchanged, and adds dedicated utility tests.

## Validation

- `uv run --extra dev pytest tests/test_build_file_parsing_util.py tests/test_check_rule_has_tag.py`
- `uv run --with ruff ruff check dev_tools/build_file_parsing_util.py dev_tools/check_rule_has_tag.py tests/test_build_file_parsing_util.py tests/test_check_rule_has_tag.py`
- `uv run --with ruff ruff format --check dev_tools/build_file_parsing_util.py dev_tools/check_rule_has_tag.py tests/test_build_file_parsing_util.py tests/test_check_rule_has_tag.py`
- `uv run --with ty ty check dev_tools/build_file_parsing_util.py dev_tools/check_rule_has_tag.py tests/test_build_file_parsing_util.py tests/test_check_rule_has_tag.py`