### PR TITLE
[codex] add check forbidden tags hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -165,6 +165,19 @@
   language: python
   types:
     - bazel
+- id: check-forbidden-tags
+  name: Check that Bazel rules do not use forbidden tags
+  description: |-
+    Check that Bazel rules do not contain forbidden tags in their `tags` attribute.
+
+    Use `--forbidden-tag` to define the disallowed tag.
+    Use `--allow-in-rule-kind` to permit that tag for rule kinds matching a regular expression.
+
+    Example args in the pre-commit config: `args: [--forbidden-tag=no-remote, --allow-in-rule-kind=pkg_tar]`
+  entry: check-forbidden-tags
+  language: python
+  types:
+    - bazel
 - id: check-non-existing-and-duplicate-excludes
   name: Check non-existing and duplicate excludes in pre-commit-config
   description: |-

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ These tools are used to help developers in their day-to-day tasks.
   - [`check-jira-reference-in-todo`](#check-jira-reference-in-todo)
   - [`check-load-statement`](#check-load-statement)
   - [`check-rule-has-tag`](#check-rule-has-tag)
+  - [`check-forbidden-tags`](#check-forbidden-tags)
   - [`check-non-existing-and-duplicate-excludes`](#check-non-existing-and-duplicate-excludes)
   - [`print-pre-commit-metrics`](#print-pre-commit-metrics)
   - [`sync-vscode-config`](#sync-vscode-config)
@@ -138,6 +139,15 @@ Alternatively, you can
 - wrap the rule with a macro that always applies these tags (combine this with the [`check-load-statement`](#check-load-statement) hook to make sure users always use the wrapper)
 
 This hook can be used multiple times to check different rules and tags.
+
+### `check-forbidden-tags`
+
+Check that Bazel rules do not contain forbidden tags in their `tags` attribute.
+
+Use `--forbidden-tag` to define the disallowed tag.
+Use `--allow-in-rule-kind` to permit that tag for rule kinds matching a regular expression.
+
+Example args in the pre-commit config: `args: [--forbidden-tag=no-remote, --allow-in-rule-kind=pkg_tar]`
 
 ### `check-non-existing-and-duplicate-excludes`
 

--- a/dev_tools/check_forbidden_tags.py
+++ b/dev_tools/check_forbidden_tags.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import re
+import sys
+from typing import TYPE_CHECKING
+
+from dev_tools.build_file_parsing_util import find_rule_calls, rule_has_tag
+from dev_tools.git_hook_utils import create_default_parser
+
+if TYPE_CHECKING:
+    import argparse
+    from collections.abc import Sequence
+    from pathlib import Path
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = create_default_parser()
+    parser.add_argument("--forbidden-tag", required=True)
+    parser.add_argument("--allow-in-rule-kind")
+    return parser.parse_args(argv)
+
+
+def find_files_with_forbidden_tags(
+    filenames: Sequence[Path],
+    forbidden_tag: str,
+    allowed_rule_kind_re: re.Pattern[str] | None,
+) -> list[Path]:
+    return [
+        filename
+        for filename in filenames
+        if any(
+            not (allowed_rule_kind_re and allowed_rule_kind_re.search(rule_call.rule_kind))
+            and rule_has_tag(rule_call.body, forbidden_tag)
+            for rule_call in find_rule_calls(filename.read_text())
+        )
+    ]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    allowed_rule_kind_re = re.compile(args.allow_in_rule_kind) if args.allow_in_rule_kind else None
+    invalid_files = find_files_with_forbidden_tags(args.filenames, args.forbidden_tag, allowed_rule_kind_re)
+
+    for filename in invalid_files:
+        if args.allow_in_rule_kind:
+            print(
+                f"Error: {filename} contains a rule with `tags` containing `{args.forbidden_tag}` outside "
+                f"a rule kind matching /{args.allow_in_rule_kind}/."
+            )
+        else:
+            print(f"Error: {filename} contains a rule with `tags` containing `{args.forbidden_tag}`.")
+
+    return 1 if invalid_files else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
 check-jira-reference-in-todo = "dev_tools.check_jira_reference_in_todo:main"
 check-load-statement = "dev_tools.check_load_statement:main"
 check-rule-has-tag = "dev_tools.check_rule_has_tag:main"
+check-forbidden-tags = "dev_tools.check_forbidden_tags:main"
 check-max-one-sentence-per-line = "dev_tools.check_max_one_sentence_per_line:main"
 check-number-of-lines-count = "dev_tools.check_number_of_lines_count:main"
 check-ownership = "dev_tools.check_ownership:main"

--- a/tests/test_check_forbidden_tags.py
+++ b/tests/test_check_forbidden_tags.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from dev_tools.check_forbidden_tags import find_files_with_forbidden_tags, main
+
+if TYPE_CHECKING:
+    from pyfakefs.fake_filesystem import FakeFilesystem
+
+
+def test_find_files_with_forbidden_tags_for_forbidden_tag_should_return_file(fs: FakeFilesystem) -> None:
+    fs.create_file(
+        Path("repo/BUILD.bazel"),
+        contents="""
+py_venv(
+    name = "bad",
+    tags = ["no-remote"],
+)
+""",
+    )
+
+    assert find_files_with_forbidden_tags([Path("repo/BUILD.bazel")], "no-remote", None) == [Path("repo/BUILD.bazel")]
+
+
+def test_find_files_with_forbidden_tags_for_allowed_rule_kind_should_return_empty_list(fs: FakeFilesystem) -> None:
+    fs.create_file(
+        Path("repo/BUILD.bazel"),
+        contents="""
+pkg_tar(
+    name = "archive",
+    tags = ["no-remote"],
+)
+""",
+    )
+
+    assert find_files_with_forbidden_tags([Path("repo/BUILD.bazel")], "no-remote", re.compile("pkg_tar")) == []
+
+
+def test_main_for_violation_should_return_one(fs: FakeFilesystem, capsys) -> None:
+    fs.create_file(
+        Path("repo/BUILD.bazel"),
+        contents="""
+py_venv(
+    name = "bad",
+    tags = ["no-remote"],
+)
+""",
+    )
+
+    assert main(["--forbidden-tag=no-remote", "repo/BUILD.bazel"]) == 1
+    assert "contains a rule with `tags` containing `no-remote`" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Adds the `check-forbidden-tags` Bazel pre-commit hook.

The hook reports Bazel rule calls containing a disallowed tag and supports `--allow-in-rule-kind` to permit that tag for rule kinds matching a regular expression.

## Validation

- `uv run --extra dev pytest tests/test_build_file_parsing_util.py tests/test_check_rule_has_tag.py tests/test_check_forbidden_tags.py`
- `uv run --with ruff ruff check dev_tools/build_file_parsing_util.py dev_tools/check_rule_has_tag.py dev_tools/check_forbidden_tags.py tests/test_build_file_parsing_util.py tests/test_check_rule_has_tag.py tests/test_check_forbidden_tags.py`
- `uv run --with ruff ruff format --check dev_tools/build_file_parsing_util.py dev_tools/check_rule_has_tag.py dev_tools/check_forbidden_tags.py tests/test_build_file_parsing_util.py tests/test_check_rule_has_tag.py tests/test_check_forbidden_tags.py`
- `uv run --with ty ty check dev_tools/build_file_parsing_util.py dev_tools/check_rule_has_tag.py dev_tools/check_forbidden_tags.py tests/test_build_file_parsing_util.py tests/test_check_rule_has_tag.py tests/test_check_forbidden_tags.py`
- `uv run check-forbidden-tags --forbidden-tag=no-remote`